### PR TITLE
Don't rely on facades

### DIFF
--- a/src/Way/Generators/Commands/GeneratorCommand.php
+++ b/src/Way/Generators/Commands/GeneratorCommand.php
@@ -84,7 +84,7 @@ abstract class GeneratorCommand extends Command {
     {
         if ($path = $this->option($option)) return $path;
 
-        return Config::get("generators.config.{$configName}");
+        return config("generators.config.{$configName}");
     }
 
     /**


### PR DESCRIPTION
They may not be available and using the `config` wrapper ensures the proper service is directly used.

Tested with Laravel 5.4